### PR TITLE
Trim BaseUrl to deal with trailing /

### DIFF
--- a/checks/httpsc/http.go
+++ b/checks/httpsc/http.go
@@ -14,7 +14,8 @@ type HttpStatusChecker struct {
 }
 
 func (h HttpStatusChecker) CheckStatus(name string) healthchecks.StatusList {
-	url := fmt.Sprintf("%s/status/aggregate", h.BaseUrl)
+	baseUrl := strings.TrimSuffix(h.BaseUrl, "/")
+	url := fmt.Sprintf("%s/status/aggregate", baseUrl)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return healthchecks.StatusList{
@@ -124,7 +125,8 @@ func (h HttpStatusChecker) Traverse(traversalPath []string, action string) (stri
 		dependencies = fmt.Sprintf("&dependencies=%s", strings.Join(traversalPath, ","))
 	}
 
-	url := fmt.Sprintf("%s/status/traverse?action=%s%s", h.BaseUrl, action, dependencies)
+	baseUrl := strings.TrimSuffix(h.BaseUrl, "/")
+	url := fmt.Sprintf("%s/status/traverse?action=%s%s",baseUrl , action, dependencies)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		fmt.Printf("Error creating request: %s \n", err.Error())

--- a/checks/httpsc/http_test.go
+++ b/checks/httpsc/http_test.go
@@ -132,6 +132,32 @@ func TestHttpStatusChecker_CheckStatusNot200(t *testing.T) {
 	}
 }
 
+func TestHttpStatusChecker_CheckStatusTrimBaseUrl(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", "http://something.com/status/aggregate",
+		httpmock.NewStringResponder(200, `["OK"]`))
+
+	// Invalid BaseUrl with extra /
+	httpStatusChecker := HttpStatusChecker{BaseUrl: "http://something.com/"}
+	status := httpStatusChecker.CheckStatus("Service name")
+
+	expected := healthchecks.StatusList{
+		StatusList: []healthchecks.Status{
+			{
+				Description: "Service name check OK",
+				Result:      healthchecks.OK,
+				Details:     "",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(status.StatusList, expected.StatusList) {
+		t.Errorf("Status response should be `%v`, was: `%v`", expected, status)
+	}
+}
+
 func TestHttpStatusChecker_Traverse(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -140,6 +166,27 @@ func TestHttpStatusChecker_Traverse(t *testing.T) {
 		httpmock.NewStringResponder(200, `something`))
 
 	httpStatusChecker := HttpStatusChecker{BaseUrl: "http://something.com"}
+	traverseResponse, err := httpStatusChecker.Traverse([]string{"aaa"}, "about")
+
+	expected := `something`
+	if traverseResponse != expected {
+		t.Errorf("Traverse response should be `%s`, was: `%s`", expected, traverseResponse)
+	}
+
+	if err != nil {
+		t.Errorf("Error should be nil")
+	}
+}
+
+func TestHttpStatusChecker_TraverseTrimBaseUrl(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", "http://something.com/status/traverse",
+		httpmock.NewStringResponder(200, `something`))
+
+	// Invalid BaseUrl with extra /
+	httpStatusChecker := HttpStatusChecker{BaseUrl: "http://something.com/"}
 	traverseResponse, err := httpStatusChecker.Traverse([]string{"aaa"}, "about")
 
 	expected := `something`


### PR DESCRIPTION
Configuring a status check with a BaseUrl like `http://something.com/` will cause the status checker to build URLs like `http://something.com//status/aggregate` and `http://something.com//status/traverse`. This PR fixes this by trimming the BaseUrl before usage.